### PR TITLE
feat: make it possible to pass additional arguments to the krr command

### DIFF
--- a/charts/simple-krr-dashboard/templates/cronjob.yaml
+++ b/charts/simple-krr-dashboard/templates/cronjob.yaml
@@ -62,7 +62,7 @@ spec:
                 {{- end }}
                 chmod +x kubectl && \
                 mv ./kubectl /usr/local/bin/kubectl && \
-                python krr.py simple --fileoutput report.table.csv --use-oomkill-data --formatter csv && \
+                python krr.py simple --fileoutput report.table.csv --use-oomkill-data --formatter csv {{ .Values.job.krrExtraArguments | default "" }} && \
                 DASHBOARD_POD=$(kubectl -n {{ .Release.Namespace }} get pods -l app.kubernetes.io/name={{ include "simple-krr-dashboard.fullname" . }} -l helm.sh/chart={{ .Chart.Name }}-{{ .Chart.Version }} -o jsonpath='{.items[0].metadata.name}') && \
                 grep -v "get-krr-report" report.table.csv > report.table.csv.tmp && \
                 kubectl -n {{ .Release.Namespace }} cp report.table.csv.tmp $DASHBOARD_POD:{{ .Values.env.KUBERNETES_DASHBOARD_CSV_PATH | default "/reports/report.table.csv" }}

--- a/charts/simple-krr-dashboard/values.yaml
+++ b/charts/simple-krr-dashboard/values.yaml
@@ -405,6 +405,9 @@ job:
   # -- Version of kubectl to install (use "stable" for latest stable version)
   kubectlVersion: "stable"
 
+  # -- Extra arguments to pass to krr (eg. `--mem-min 32 --allow-hpa --history-duration 720`)
+  krrExtraArguments: ""
+
   # -- Concurrency policy for the cronjob
   concurrencyPolicy: "Forbid"
 


### PR DESCRIPTION
<!--
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/devops-ia/.github/blob/main/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes. The PR will be squashed anyways when it is merged.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

PR Steps:
1) Please make sure you test your changes before you push them.
2) Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
3) These checks run very quickly.
4) Please check the results.
5) We would like these checks to pass before we even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Makes it possible to pass additional arguments to the krr report cronjob. This allows for tweaks such as:
- setting the minimum memory value
- setting the minimum cpu value
- duration of the Prometheus history data to use
- enabling recommendations for workloads with HPA

#### Which issue this PR fixes

- implements #1 

#### Special notes for your reviewer:

Hey @ialejandro,

I thought it would be a bit simpler to use a direct configuration item similarly to how the kubectl version is configured (`job.kubectlVersion`) than going through an extra layer of environment variables. 

#### Checklist

- [x] [DCO](https://github.com/devops-ia/.github/blob/main/CONTRIBUTING.md) signed
