### PR TITLE
fix: workflow does not contain permissions

### DIFF
--- a/.github/workflows/helm-lint-test.yml
+++ b/.github/workflows/helm-lint-test.yml
@@ -1,5 +1,8 @@
 name: Lint and Test Helm Charts
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   pull_request:

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   release:
+    permissions:
+      contents: read
     uses: devops-ia/.github/.github/workflows/helm-release.yml@main
     with:
       chart_name: simple-krr-dashboard


### PR DESCRIPTION
Potential fix for [https://github.com/devops-ia/helm-simple-krr-dashboard/security/code-scanning/6](https://github.com/devops-ia/helm-simple-krr-dashboard/security/code-scanning/6)

To fix the problem, explicitly declare the GitHub token permissions for this workflow, using the principle of least privilege. Since this file’s `release` job only delegates to a reusable workflow via `uses:`, the most robust and non‑breaking fix is to add a `permissions` block at the job level (under `jobs.release`) specifying read‑only access to `contents`. This will cap the `GITHUB_TOKEN` permissions available to this job regardless of repository defaults. If the reusable workflow requires more specific permissions (like `packages: write` or `contents: write`), they can be added later after reviewing its implementation, but we should start from the minimal safe baseline.

Concretely:
- Edit `.github/workflows/helm-release.yml`.
- Under `jobs.release`, add:

  ```yaml
    permissions:
      contents: read
  ```

- Keep the existing `uses:` and `with:` configuration unchanged.

This change does not alter workflow triggers or behavior; it only constrains the token’s rights when the job runs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
