### PR TITLE
fix: workflow does not contain permissions

### DIFF
--- a/.github/workflows/helm-lint-test.yml
+++ b/.github/workflows/helm-lint-test.yml
@@ -1,5 +1,8 @@
 name: Lint and Test Helm Charts
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/devops-ia/helm-simple-krr-dashboard/security/code-scanning/5](https://github.com/devops-ia/helm-simple-krr-dashboard/security/code-scanning/5)

In general, the fix is to add an explicit `permissions` block that grants only the minimal required scopes to the `GITHUB_TOKEN`. For a lint-and-test workflow, read access to repository contents is typically sufficient. Since this workflow delegates all work to a reusable workflow via `uses:`, and we’re not shown any need for write operations, we should set `contents: read` at the workflow root so it applies to all jobs (including `lint-test`).

Concretely, update `.github/workflows/helm-lint-test.yml` by inserting a `permissions` section after the `name` (or before `on:`) at the top level:

- Add:
  ```yaml
  permissions:
    contents: read
  ```
- Do not alter the existing `on:` triggers or the `jobs.lint-test.uses` line.
- No additional imports or methods are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
