### PR TITLE
fix: matchLabels overlaps with cronjob

### DIFF
--- a/charts/simple-krr-dashboard/templates/cronjob.yaml
+++ b/charts/simple-krr-dashboard/templates/cronjob.yaml
@@ -35,7 +35,8 @@ spec:
           {{- end }}
           labels:
             {{- include "simple-krr-dashboard.selectorLabels" . | nindent 12 }}
-            {{- with .Values.jobpodLabels }}
+            app.kubernetes.io/component: cronjob
+            {{- with .Values.job.podLabels }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
         spec:

--- a/charts/simple-krr-dashboard/templates/deployment.yaml
+++ b/charts/simple-krr-dashboard/templates/deployment.yaml
@@ -22,7 +22,6 @@ spec:
   selector:
     matchLabels:
       {{- include "simple-krr-dashboard.selectorLabels" . | nindent 6 }}
-      deployment: {{ include "simple-krr-dashboard.fullname" . }}
   template:
     metadata:
       annotations:
@@ -32,7 +31,7 @@ spec:
         {{- end }}
       labels:
         {{- include "simple-krr-dashboard.labels" . | nindent 8 }}
-        deployment: {{ include "simple-krr-dashboard.fullname" . }}
+        app.kubernetes.io/component: deployment
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/simple-krr-dashboard/templates/deployment.yaml
+++ b/charts/simple-krr-dashboard/templates/deployment.yaml
@@ -22,6 +22,7 @@ spec:
   selector:
     matchLabels:
       {{- include "simple-krr-dashboard.selectorLabels" . | nindent 6 }}
+      deployment: {{ include "simple-krr-dashboard.fullname" . }}
   template:
     metadata:
       annotations:
@@ -31,6 +32,7 @@ spec:
         {{- end }}
       labels:
         {{- include "simple-krr-dashboard.labels" . | nindent 8 }}
+        deployment: {{ include "simple-krr-dashboard.fullname" . }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/simple-krr-dashboard/templates/job.yaml
+++ b/charts/simple-krr-dashboard/templates/job.yaml
@@ -29,6 +29,7 @@ spec:
       {{- end }}
       labels:
         {{- include "simple-krr-dashboard.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: cronjob
         {{- with .Values.job.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

* fix: add extra labels in deployment to prevent overlaps with cronjob.

#### Which issue this PR fixes

- fixes #24

#### Special notes for your reviewer:

I use "deployment" as a kubernetes label. If you have a better label name I'm open to change.

#### Checklist

- [x] [DCO](https://github.com/devops-ia/.github/blob/main/CONTRIBUTING.md) signed
