### PR TITLE
fix: new release 1.6.1

### DIFF
--- a/charts/simple-krr-dashboard/Chart.yaml
+++ b/charts/simple-krr-dashboard/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 sources:
   - https://github.com/devops-ia/simple-krr-dashboard
 version: 0.0.1
-appVersion: 1.6.0
+appVersion: 1.6.1
 home: https://github.com/devops-ia/helm-simple-krr-dashboard
 keywords:
   - simple-krr-dashboard


### PR DESCRIPTION
Simple KRR Dashboard version:
- :information_source: Current: `1.6.0`
- :up: Upgrade: `1.6.1`

Changelog: https://github.com/devops-ia/simple-krr-dashboard/releases/tag/1.6.1